### PR TITLE
fix a bug can't receive message larger than BUFSIZ

### DIFF
--- a/lib/hpfeeds.py
+++ b/lib/hpfeeds.py
@@ -176,7 +176,17 @@ class HPC(object):
 			self._subscribe()
 			while self.connected:
 				try:
+					flag = True
 					d = self.recv()
+					buf = bytearray()
+					buf.extend(d)
+					msgLength,temp = struct.unpack('!iB',buffer(buf,0,5))
+					while flag:
+						r = self.recv()
+						if not r: break
+						d += r
+						if len(d) == msgLength:
+							flag = False
 					self.unpacker.feed(d)
 
 					for opcode, data in self.unpacker:


### PR DESCRIPTION
I have recently used hpfeed to transmit a file larger than BUFSIZ, but the hpfeed.py only receive once so I can't receive the whole file. I fix this problem by receive more times.  
